### PR TITLE
ADM remediating 19 vulnerable artifacts

### DIFF
--- a/datax-admin/pom.xml
+++ b/datax-admin/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-context</artifactId>
-            <version>${spring-boot.version}</version>
+            <version>3.1.7</version>
         </dependency>
 
         <dependency>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-boot-starter</artifactId>
-            <version>${mybatisplus.version}</version>
+            <version>3.5.3.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.baomidou</groupId>
@@ -92,13 +92,13 @@
         <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus</artifactId>
-            <version>${mybatisplus.version}</version>
+            <version>3.5.3.1</version>
         </dependency>
         <!-- 接口管理 -->
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>${swagger.version}</version>
+            <version>2.10.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.swagger</groupId>
@@ -146,13 +146,13 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>${fastjson.version}</version>
+            <version>1.2.83</version>
         </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
+            <version>42.2.27</version>
         </dependency>
 
         <dependency>
@@ -180,7 +180,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback-classic.version}</version>
+            <version>1.2.9</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
@@ -192,7 +192,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql-connector.version}</version>
+            <version>8.0.31</version>
         </dependency>
 
         <!-- datax-core -->
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.13.1</version>
         </dependency>
         <!-- mail-starter -->
         <dependency>
@@ -228,13 +228,13 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>30.0-jre</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
+            <version>3.3.6</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -318,7 +318,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
-            <version>${hive.jdbc.version}</version>
+            <version>4.0.0-alpha-2</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jsr305</artifactId>
@@ -518,7 +518,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
-            <version>${hadoop.version}</version>
+            <version>3.3.5</version>
             <exclusions>
                 <exclusion>
                     <artifactId>guava</artifactId>
@@ -554,7 +554,7 @@
         <dependency>
             <groupId>org.apache.hbase</groupId>
             <artifactId>hbase-client</artifactId>
-            <version>${hbase.version}</version>
+            <version>2.5.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>guava</artifactId>
@@ -602,7 +602,7 @@
         <dependency>
             <groupId>org.apache.phoenix</groupId>
             <artifactId>phoenix-core</artifactId>
-            <version>${phoenix.version}</version>
+            <version>5.1.3</version>
             <exclusions>
                 <exclusion>
                     <artifactId>slf4j-log4j12</artifactId>
@@ -770,13 +770,13 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>${mongo-java-driver.version}</version>
+            <version>3.4.3</version>
         </dependency>
 
         <dependency>
             <groupId>ru.yandex.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
-            <version>0.2.4</version>
+            <version>0.3.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>guava</artifactId>

--- a/datax-core/pom.xml
+++ b/datax-core/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>${groovy.version}</version>
+            <version>2.5.14</version>
         </dependency>
 
         <!-- spring-context -->

--- a/datax-rpc/pom.xml
+++ b/datax-rpc/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>${netty.version}</version>
+            <version>4.1.46.Final</version>
         </dependency>
 
         <!-- hessian -->


### PR DESCRIPTION
Vulnerabilities: [Remediation Run Detect Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialya7kiknzp7ejkqgpzfrinhizfnnoenf35cifaa4whlvelq/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyacp67pnsgkzmptjlkbpoixgx5bpa5vfbqbvwgtvywxtoa/stages/DETECT)
* com.wugui:datax-admin:2.1.2
  * ch.qos.logback:logback-classic:1.2.2
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
  * com.alibaba:fastjson:1.2.70
    * CVE-2022-25845
  * com.baomidou:mybatis-plus-boot-starter:3.3.1
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.alibaba:fastjson:1.2.70
      * CVE-2022-25845
    * com.baomidou:mybatis-plus:3.3.1
      * CVE-2023-25330
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
      * CVE-2020-36188
      * CVE-2020-36189
      * CVE-2020-36518
      * CVE-2020-8840
      * CVE-2020-9546
      * CVE-2020-9547
      * CVE-2020-9548
      * CVE-2021-20190
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * junit:junit:4.12
      * CVE-2020-15250
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.httpcomponents:httpclient:4.5.8
      * CVE-2020-13956
    * org.apache.logging.log4j:log4j-api:2.11.2
      * CVE-2021-45105
    * org.apache.logging.log4j:log4j-core:2.11.2
      * CVE-2020-9488
      * CVE-2021-44228
      * CVE-2021-44832
      * CVE-2021-45046
      * CVE-2021-45105
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.17
      * CVE-2019-0221
      * CVE-2019-0232
      * CVE-2019-10072
      * CVE-2019-12418
      * CVE-2019-17563
      * CVE-2020-11996
      * CVE-2020-13934
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2020-1935
      * CVE-2020-1938
      * CVE-2020-9484
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.codehaus.groovy:groovy:2.5.6
      * CVE-2020-17521
    * org.hibernate.validator:hibernate-validator:6.0.16.Final
      * CVE-2019-10219
      * CVE-2020-10693
    * org.mybatis:mybatis:3.5.3
      * CVE-2020-26945
    * org.springframework.boot:spring-boot:2.1.4.RELEASE
      * CVE-2022-27772
    * org.springframework.security:spring-security-core:5.1.5.RELEASE
      * CVE-2020-5408
      * CVE-2022-22976
      * CVE-2022-22978
    * org.springframework.security:spring-security-web:5.1.5.RELEASE
      * CVE-2021-22112
    * org.springframework:spring-beans:5.1.6.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.1.6.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.1.6.RELEASE
      * CVE-2020-5398
      * CVE-2020-5421
    * org.springframework:spring-webmvc:5.1.6.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.23
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * com.baomidou:mybatis-plus:3.3.1
    * CVE-2023-25330
    * com.alibaba:fastjson:1.2.70
      * CVE-2022-25845
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
      * CVE-2020-36188
      * CVE-2020-36189
      * CVE-2020-36518
      * CVE-2020-8840
      * CVE-2020-9546
      * CVE-2020-9547
      * CVE-2020-9548
      * CVE-2021-20190
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.logging.log4j:log4j-api:2.11.2
      * CVE-2021-45105
    * org.apache.logging.log4j:log4j-core:2.11.2
      * CVE-2020-9488
      * CVE-2021-44228
      * CVE-2021-44832
      * CVE-2021-45046
      * CVE-2021-45105
    * org.codehaus.groovy:groovy:2.5.6
      * CVE-2020-17521
    * org.mybatis:mybatis:3.5.3
      * CVE-2020-26945
    * org.springframework:spring-beans:5.1.6.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.1.6.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.yaml:snakeyaml:1.23
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * com.google.guava:guava:29.0-jre
    * CVE-2020-8908
  * com.wugui:datax-core:2.1.2
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.codehaus.groovy:groovy:2.5.6
      * CVE-2020-17521
  * io.jsonwebtoken:jjwt:0.9.0
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
      * CVE-2020-36188
      * CVE-2020-36189
      * CVE-2020-36518
      * CVE-2020-8840
      * CVE-2020-9546
      * CVE-2020-9547
      * CVE-2020-9548
      * CVE-2021-20190
      * CVE-2022-42003
      * CVE-2022-42004
  * io.springfox:springfox-swagger2:2.9.2
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.apache.logging.log4j:log4j-api:2.11.2
      * CVE-2021-45105
    * org.codehaus.groovy:groovy:2.5.6
      * CVE-2020-17521
    * org.springframework:spring-beans:5.1.6.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.1.6.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.yaml:snakeyaml:1.23
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * junit:junit:4.12
    * CVE-2020-15250
  * mysql:mysql-connector-java:5.1.47
    * CVE-2018-3258
    * CVE-2019-2692
    * CVE-2020-2875
    * CVE-2020-2933
    * CVE-2020-2934
    * CVE-2022-21363
  * org.apache.hadoop:hadoop-common:2.7.3
    * CVE-2018-8009
    * CVE-2020-9492
    * CVE-2022-26612
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.jcraft:jsch:0.1.42
      * CVE-2016-5725
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-httpclient:commons-httpclient:3.1
      * CVE-2012-5783
    * commons-io:commons-io:2.4
      * CVE-2021-29425
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.httpcomponents:httpclient:4.5.8
      * CVE-2020-13956
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.2
      * CVE-2019-10172
  * org.apache.hadoop:hadoop-hdfs:2.7.3
    * CVE-2018-11768
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * commons-io:commons-io:2.4
      * CVE-2021-29425
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.codehaus.jackson:jackson-mapper-asl:1.9.2
      * CVE-2019-10172
    * xerces:xercesImpl:2.9.1
      * CVE-2009-2625
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
  * org.apache.hbase:hbase-client:1.3.0
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.jcraft:jsch:0.1.42
      * CVE-2016-5725
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-httpclient:commons-httpclient:3.1
      * CVE-2012-5783
    * commons-io:commons-io:2.4
      * CVE-2021-29425
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * junit:junit:4.12
      * CVE-2020-15250
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.hadoop:hadoop-common:2.7.3
      * CVE-2018-8009
      * CVE-2020-9492
      * CVE-2022-26612
    * org.apache.httpcomponents:httpclient:4.5.8
      * CVE-2020-13956
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.2
      * CVE-2019-10172
  * org.apache.hive:hive-jdbc:2.1.0
    * CVE-2018-1282
    * CVE-2018-1314
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
      * CVE-2020-36188
      * CVE-2020-36189
      * CVE-2020-36518
      * CVE-2020-8840
      * CVE-2020-9546
      * CVE-2020-9547
      * CVE-2020-9548
      * CVE-2021-20190
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.jcraft:jsch:0.1.42
      * CVE-2016-5725
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-httpclient:commons-httpclient:3.1
      * CVE-2012-5783
    * commons-io:commons-io:2.4
      * CVE-2021-29425
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * junit:junit:4.12
      * CVE-2020-15250
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.hadoop:hadoop-common:2.7.3
      * CVE-2018-8009
      * CVE-2020-9492
      * CVE-2022-26612
    * org.apache.hadoop:hadoop-hdfs:2.7.3
      * CVE-2018-11768
    * org.apache.hadoop:hadoop-yarn-server-common:2.6.0
      * CVE-2021-33036
    * org.apache.hive:hive-service:2.1.0
      * CVE-2017-12625
      * CVE-2018-1284
      * CVE-2018-1315
    * org.apache.httpcomponents:httpclient:4.5.8
      * CVE-2020-13956
    * org.apache.logging.log4j:log4j-api:2.11.2
      * CVE-2021-45105
    * org.apache.logging.log4j:log4j-core:2.11.2
      * CVE-2020-9488
      * CVE-2021-44228
      * CVE-2021-44832
      * CVE-2021-45046
      * CVE-2021-45105
    * org.apache.thrift:libfb303:0.9.3
      * CVE-2019-0210
    * org.apache.thrift:libthrift:0.9.0
      * CVE-2015-3254
      * CVE-2018-1320
      * CVE-2019-0205
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.17
      * CVE-2019-0221
      * CVE-2019-0232
      * CVE-2019-10072
      * CVE-2019-12418
      * CVE-2019-17563
      * CVE-2020-11996
      * CVE-2020-13934
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2020-1935
      * CVE-2020-1938
      * CVE-2020-9484
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.2
      * CVE-2019-10172
    * xerces:xercesImpl:2.9.1
      * CVE-2009-2625
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
  * org.apache.phoenix:phoenix-core:5.0.0-HBase-2.0
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
      * CVE-2020-36188
      * CVE-2020-36189
      * CVE-2020-36518
      * CVE-2020-8840
      * CVE-2020-9546
      * CVE-2020-9547
      * CVE-2020-9548
      * CVE-2021-20190
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.jcraft:jsch:0.1.42
      * CVE-2016-5725
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-httpclient:commons-httpclient:3.1
      * CVE-2012-5783
    * commons-io:commons-io:2.4
      * CVE-2021-29425
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * junit:junit:4.12
      * CVE-2020-15250
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.hadoop:hadoop-common:2.7.3
      * CVE-2018-8009
      * CVE-2020-9492
      * CVE-2022-26612
    * org.apache.hadoop:hadoop-hdfs:2.7.3
      * CVE-2018-11768
    * org.apache.httpcomponents:httpclient:4.5.8
      * CVE-2020-13956
    * org.apache.thrift:libthrift:0.9.0
      * CVE-2015-3254
      * CVE-2018-1320
      * CVE-2019-0205
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.2
      * CVE-2019-10172
    * xerces:xercesImpl:2.9.1
      * CVE-2009-2625
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
  * org.postgresql:postgresql:42.2.5
    * CVE-2022-21724
    * CVE-2022-31197
    * CVE-2022-41946
  * org.springframework.boot:spring-boot-starter-actuator:2.1.4.RELEASE
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
      * CVE-2020-36188
      * CVE-2020-36189
      * CVE-2020-36518
      * CVE-2020-8840
      * CVE-2020-9546
      * CVE-2020-9547
      * CVE-2020-9548
      * CVE-2021-20190
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * junit:junit:4.12
      * CVE-2020-15250
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.httpcomponents:httpclient:4.5.8
      * CVE-2020-13956
    * org.apache.logging.log4j:log4j-api:2.11.2
      * CVE-2021-45105
    * org.apache.logging.log4j:log4j-core:2.11.2
      * CVE-2020-9488
      * CVE-2021-44228
      * CVE-2021-44832
      * CVE-2021-45046
      * CVE-2021-45105
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.17
      * CVE-2019-0221
      * CVE-2019-0232
      * CVE-2019-10072
      * CVE-2019-12418
      * CVE-2019-17563
      * CVE-2020-11996
      * CVE-2020-13934
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2020-1935
      * CVE-2020-1938
      * CVE-2020-9484
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.codehaus.groovy:groovy:2.5.6
      * CVE-2020-17521
    * org.hibernate.validator:hibernate-validator:6.0.16.Final
      * CVE-2019-10219
      * CVE-2020-10693
    * org.springframework.boot:spring-boot:2.1.4.RELEASE
      * CVE-2022-27772
    * org.springframework.security:spring-security-core:5.1.5.RELEASE
      * CVE-2020-5408
      * CVE-2022-22976
      * CVE-2022-22978
    * org.springframework.security:spring-security-web:5.1.5.RELEASE
      * CVE-2021-22112
    * org.springframework:spring-beans:5.1.6.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.1.6.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.1.6.RELEASE
      * CVE-2020-5398
      * CVE-2020-5421
    * org.springframework:spring-webmvc:5.1.6.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.23
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.springframework.boot:spring-boot-starter-mail:2.1.4.RELEASE
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
      * CVE-2020-36188
      * CVE-2020-36189
      * CVE-2020-36518
      * CVE-2020-8840
      * CVE-2020-9546
      * CVE-2020-9547
      * CVE-2020-9548
      * CVE-2021-20190
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.code.gson:gson:2.8.5
      * CVE-2022-25647
    * com.google.guava:guava:29.0-jre
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty-all:4.1.34.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2019-9518
      * CVE-2020-11612
    * junit:junit:4.12
      * CVE-2020-15250
    * log4j:log4j:1.2.17
      * CVE-2019-17571
      * CVE-2021-4104
      * CVE-2022-23302
      * CVE-2022-23305
      * CVE-2022-23307
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.apache.commons:commons-compress:1.4.1
      * CVE-2018-11771
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.httpcomponents:httpclient:4.5.8
      * CVE-2020-13956
    * org.apache.logging.log4j:log4j-api:2.11.2
      * CVE-2021-45105
    * org.apache.logging.log4j:log4j-core:2.11.2
      * CVE-2020-9488
      * CVE-2021-44228
      * CVE-2021-44832
      * CVE-2021-45046
      * CVE-2021-45105
    * org.apache.tomcat.embed:tomcat-embed-core:9.0.17
      * CVE-2019-0221
      * CVE-2019-0232
      * CVE-2019-10072
      * CVE-2019-12418
      * CVE-2019-17563
      * CVE-2020-11996
      * CVE-2020-13934
      * CVE-2020-13943
      * CVE-2020-17527
      * CVE-2020-1935
      * CVE-2020-1938
      * CVE-2020-9484
      * CVE-2021-24122
      * CVE-2021-25122
      * CVE-2021-25329
      * CVE-2021-30640
      * CVE-2021-33037
    * org.codehaus.groovy:groovy:2.5.6
      * CVE-2020-17521
    * org.hibernate.validator:hibernate-validator:6.0.16.Final
      * CVE-2019-10219
      * CVE-2020-10693
    * org.springframework.boot:spring-boot:2.1.4.RELEASE
      * CVE-2022-27772
    * org.springframework.security:spring-security-core:5.1.5.RELEASE
      * CVE-2020-5408
      * CVE-2022-22976
      * CVE-2022-22978
    * org.springframework.security:spring-security-web:5.1.5.RELEASE
      * CVE-2021-22112
    * org.springframework:spring-beans:5.1.6.RELEASE
      * CVE-2022-22965
    * org.springframework:spring-core:5.1.6.RELEASE
      * CVE-2016-1000027
      * CVE-2021-22060
      * CVE-2022-22950
      * CVE-2022-22968
      * CVE-2022-22970
      * CVE-2022-22971
      * CVE-2023-20861
    * org.springframework:spring-web:5.1.6.RELEASE
      * CVE-2020-5398
      * CVE-2020-5421
    * org.springframework:spring-webmvc:5.1.6.RELEASE
      * CVE-2020-5421
      * CVE-2022-22965
    * org.yaml:snakeyaml:1.23
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.springframework.boot:spring-boot-starter-security:2.1.4.RELEASE
    * ch.qos.logback:logback-core:1.2.3
      * CVE-2021-42550
    * com.fasterxml.jackson.core:jackson-databind:2.9.8
      * CVE-2019-12086
      * CVE-2019-12384
      * CVE-2019-12814
      * CVE-2019-14379
      * CVE-2019-14439
      * CVE-2019-14540
      * CVE-2019-14892
      * CVE-2019-14893
      * CVE-2019-16335
      * CVE-2019-16942
      * CVE-2019-16943
      * CVE-2019-17267
      * CVE-2019-17531
      * CVE-2019-20330
      * CVE-2020-10650
      * CVE-2020-10672
      * CVE-2020-10673
      * CVE-2020-10968
      * CVE-2020-10969
      * CVE-2020-11111
      * CVE-2020-11112
      * CVE-2020-11113
      * CVE-2020-11619
      * CVE-2020-11620
      * CVE-2020-14060
      * CVE-2020-14061
      * CVE-2020-14062
      * CVE-2020-14195
      * CVE-2020-24616
      * CVE-2020-24750
      * CVE-2020-25649
      * CVE-2020-35490
      * CVE-2020-35491
      * CVE-2020-35728
      * CVE-2020-36179
      * CVE-2020-36180
      * CVE-2020-36181
      * CVE-2020-36182
      * CVE-2020-36183
      * CVE-2020-36184
      * CVE-2020-36185
      * CVE-2020-36186
      * CVE-2020-36187
...
Dependencies upgraded: [Remediation Run Recommend Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialya7kiknzp7ejkqgpzfrinhizfnnoenf35cifaa4whlvelq/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyacp67pnsgkzmptjlkbpoixgx5bpa5vfbqbvwgtvywxtoa/stages/RECOMMEND)

* ch.qos.logback:logback-classic:1.2.2 -> 1.2.9
* com.alibaba:fastjson:1.2.70 -> 1.2.83
* com.baomidou:mybatis-plus-boot-starter:3.3.1 -> 3.5.3.1
* com.baomidou:mybatis-plus:3.3.1 -> 3.5.3.1
* com.google.guava:guava:29.0-jre -> 30.0-jre
* io.netty:netty-all:4.1.43.Final -> 4.1.46.Final
* io.springfox:springfox-swagger2:2.9.2 -> 2.10.0
* junit:junit:4.12 -> 4.13.1
* mysql:mysql-connector-java:5.1.47 -> 8.0.31
* org.apache.hadoop:hadoop-common:2.7.3 -> 3.3.6
* org.apache.hadoop:hadoop-hdfs:2.7.3 -> 3.3.5
* org.apache.hbase:hbase-client:1.3.0 -> 2.5.0
* org.apache.hive:hive-jdbc:2.1.0 -> 4.0.0-alpha-2
* org.apache.phoenix:phoenix-core:5.0.0-HBase-2.0 -> 5.1.3
* org.codehaus.groovy:groovy:2.5.8 -> 2.5.14
* org.mongodb:mongo-java-driver:3.4.2 -> 3.4.3
* org.postgresql:postgresql:42.2.5 -> 42.2.27
* org.springframework.cloud:spring-cloud-context:2.1.4.RELEASE -> 3.1.7
* ru.yandex.clickhouse:clickhouse-jdbc:0.2.4 -> 0.3.0

Auto-merge is disabled.